### PR TITLE
Ajusta lógica para atribuição de IDs únicos

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Service/UserService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/UserService.cs
@@ -127,11 +127,13 @@ namespace ApiAcademiaUnifor.ApiService.Service
                 userDto.Id = 0; 
 
                 var lista = await _supabase.From<Models.User>().Get();
-                int id = lista.Models.Any() ? lista.Models.Max(e => e.Id) : 0;
+                int nextId = lista.Models.Any()
+                    ? lista.Models.Max(e => e.Id) + 1
+                    : 1; ;
 
                 var user = new Models.User
                 {
-                    Id = id + 1,
+                    Id = nextId,
                     Password = userDto.Password,
                     Name = userDto.Name,
                     Email = userDto.Email,

--- a/ApiAcademiaUnifor.ApiService/Service/WorkoutService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/WorkoutService.cs
@@ -110,15 +110,19 @@ namespace ApiAcademiaUnifor.ApiService.Service
             try
             {
                 var lista = await _supabase.From<Workout>().Get();
-                int id = lista.Models.Any() ? lista.Models.Max(e => e.Id) : 0;
+
+                int nextId = lista.Models.Any()
+                    ? lista.Models.Max(e => e.Id) + 1
+                    : 1;
                 var workout = new Workout
                 {
-                    Id = id + 1,
+                    Id = nextId,
                     UserId = workoutDto.UserId,
                     Name = workoutDto.Name,
                     Description = workoutDto.Description
                 };
                 await _supabase.From<Workout>().Insert(workout);
+                workoutDto.Id = nextId;
                 return workoutDto;
             }
             catch (Exception ex)


### PR DESCRIPTION
Modifica a forma como o próximo ID é determinado para novos usuários e treinos. Agora, o código verifica se existem registros na lista e calcula o próximo ID como o máximo existente mais 1, ou 1 se não houver registros. Isso evita a possibilidade de IDs duplicados e garante que o ID comece em 1 quando não houver registros.