### PR TITLE
Add CORS support with "AllowAll" policy

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Program.cs
+++ b/ApiAcademiaUnifor.ApiService/Program.cs
@@ -29,6 +29,14 @@ await supabaseClient.InitializeAsync();
 
 builder.Services.AddSingleton(supabaseClient);
 
+builder.Services.AddCors(options =>
+{
+    options.AddPolicy("AllowAll", policy =>
+    {
+        policy.AllowAnyOrigin().AllowAnyMethod().AllowAnyHeader();
+    });
+});
+
 // Seus serviços
 builder.Services.AddScoped<UserService>();
 builder.Services.AddScoped<GymEquipmentService>();
@@ -40,6 +48,8 @@ var app = builder.Build();
 
 // Configura tratamento de exceção com rota
 app.UseExceptionHandler("/error");
+
+app.UseCors("AllowAll");
 
 // Endpoint para tratar exceções
 app.Map("/error", (HttpContext httpContext) =>


### PR DESCRIPTION
This commit introduces CORS (Cross-Origin Resource Sharing) support in the application. A new CORS policy named "AllowAll" is added, allowing any origin, method, and header. The application is configured to use this policy by calling `app.UseCors("AllowAll")` after building the application, enabling it to handle requests from different origins effectively.