### PR TITLE
Add usage count endpoint for equipment

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Controller/ExerciseController.cs
+++ b/ApiAcademiaUnifor.ApiService/Controller/ExerciseController.cs
@@ -50,6 +50,21 @@ namespace ApiAcademiaUnifor.ApiService.Controller
             }
         }
 
+        [HttpGet("count/{equipmentId}")]
+        public async Task<IActionResult> GetUsageCountForEquipment(int equipmentId)
+        {
+            try
+            {
+                var count = await _exerciseService.GetUsageCountForEquipment(equipmentId);
+                return Ok(count);
+            }
+            catch (Exception ex)
+            {
+                return BadRequest(new { error = ex.Message });
+            }
+        }
+
+
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] ExerciseDto exerciseDto)
         {

--- a/ApiAcademiaUnifor.ApiService/Properties/launchSettings.json
+++ b/ApiAcademiaUnifor.ApiService/Properties/launchSettings.json
@@ -5,7 +5,7 @@
       "commandName": "Project",
       "dotnetRunMessages": true,
       "launchBrowser": false,
-      "applicationUrl": "http://localhost:5404",
+      "applicationUrl": "http://localhost:5404;http://0.0.0.0:5404",
       "environmentVariables": {
         "ASPNETCORE_ENVIRONMENT": "Development",
         "SUPABASE_URL": "https://regjvzhfbouqrcgcghim.supabase.co",

--- a/ApiAcademiaUnifor.ApiService/Service/ExerciseService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/ExerciseService.cs
@@ -100,6 +100,29 @@ namespace ApiAcademiaUnifor.ApiService.Service
             }
         }
 
+        public async Task<int> GetUsageCountForEquipment(int equipmentId)
+        {
+            try
+            {
+                var result = await _supabase
+                .From<Exercise>()
+                .Where(e => e.EquipmentId == equipmentId)
+                .Get();
+
+                var exerciseResult = result.Models.ToList();
+
+                if (exerciseResult == null)
+                    throw new Exception("Equipamento não existe ou não é utilizado");
+
+                return exerciseResult.Count;
+                
+            }
+            catch (Exception ex)
+            {
+                throw new Exception(ex.Message);
+            }
+        }
+
         public async Task<ExerciseDto> Post(ExerciseDto exerciseDto)
         {
             try


### PR DESCRIPTION
- Implemented a new GET endpoint in `ExerciseController` to retrieve the usage count for equipment by ID.
- Updated `launchSettings.json` to allow access from both `localhost` and `0.0.0.0`.
- Added `GetUsageCountForEquipment` method in `ExerciseService` to query Supabase for exercise counts, with error handling for non-existent equipment.