### PR TITLE
Remove usage count methods and improve DTO handling

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Controller/ExerciseController.cs
+++ b/ApiAcademiaUnifor.ApiService/Controller/ExerciseController.cs
@@ -50,21 +50,6 @@ namespace ApiAcademiaUnifor.ApiService.Controller
             }
         }
 
-        [HttpGet("count/{equipmentId}")]
-        public async Task<IActionResult> GetUsageCountForEquipment(int equipmentId)
-        {
-            try
-            {
-                var count = await _exerciseService.GetUsageCountForEquipment(equipmentId);
-                return Ok(count);
-            }
-            catch (Exception ex)
-            {
-                return BadRequest(new { error = ex.Message });
-            }
-        }
-
-
         [HttpPost]
         public async Task<IActionResult> Post([FromBody] ExerciseDto exerciseDto)
         {

--- a/ApiAcademiaUnifor.ApiService/Service/ExerciseService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/ExerciseService.cs
@@ -100,29 +100,6 @@ namespace ApiAcademiaUnifor.ApiService.Service
             }
         }
 
-        public async Task<int> GetUsageCountForEquipment(int equipmentId)
-        {
-            try
-            {
-                var result = await _supabase
-                .From<Exercise>()
-                .Where(e => e.EquipmentId == equipmentId)
-                .Get();
-
-                var exerciseResult = result.Models.ToList();
-
-                if (exerciseResult == null)
-                    throw new Exception("Equipamento não existe ou não é utilizado");
-
-                return exerciseResult.Count;
-                
-            }
-            catch (Exception ex)
-            {
-                throw new Exception(ex.Message);
-            }
-        }
-
         public async Task<ExerciseDto> Post(ExerciseDto exerciseDto)
         {
             try

--- a/ApiAcademiaUnifor.ApiService/Service/GymEquipmentService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/GymEquipmentService.cs
@@ -23,17 +23,25 @@ namespace ApiAcademiaUnifor.ApiService.Service
                     .From<GymEquipment>()
                     .Get();
 
-                var equipmentDtoList = equipmentRecords.Models.Select(equipment => new GymEquipmentDto
+                var equipmentDtoList = new List<GymEquipmentDto>();
+
+                foreach (var equipment in equipmentRecords.Models)
                 {
-                    Id = equipment.Id,
-                    CategoryId = equipment.CategoryId,
-                    Name = equipment.Name,
-                    Brand = equipment.Brand,
-                    Model = equipment.Model,
-                    Quantity = equipment.Quantity,
-                    Image = equipment.Image,
-                    Operational = equipment.Operational == false ? false : null
-                }).ToList();
+                    var quantityInUse = await GetEquipmentUsageCount(equipment.Id); // Await the Task<int> here
+
+                    equipmentDtoList.Add(new GymEquipmentDto
+                    {
+                        Id = equipment.Id,
+                        CategoryId = equipment.CategoryId,
+                        Name = equipment.Name,
+                        Brand = equipment.Brand,
+                        Model = equipment.Model,
+                        Quantity = equipment.Quantity,
+                        Image = equipment.Image,
+                        Operational = equipment.Operational == false ? false : null,
+                        QuantityInUse = quantityInUse // Assign the awaited result
+                    });
+                }
 
                 return equipmentDtoList;
             }
@@ -58,6 +66,8 @@ namespace ApiAcademiaUnifor.ApiService.Service
                 if (equipment == null)
                     throw new Exception("Equipamento não encontrado");
 
+                var quantityInUse = await GetEquipmentUsageCount(equipment.Id); // Await the Task<int> here
+
                 var equipmentDto = new GymEquipmentDto
                 {
                     Id = equipment.Id,
@@ -67,7 +77,9 @@ namespace ApiAcademiaUnifor.ApiService.Service
                     Model = equipment.Model,
                     Quantity = equipment.Quantity,
                     Image = equipment.Image,
-                    Operational = equipment.Operational == false ? false : null
+                    Operational = equipment.Operational == false ? false : null,
+                    QuantityInUse = quantityInUse // Assign the awaited result
+
                 };
 
                 return equipmentDto;
@@ -93,17 +105,25 @@ namespace ApiAcademiaUnifor.ApiService.Service
                 if (equipmentList == null)
                     throw new Exception("Nenhum equipamento encontrado para esta categoria.");
 
-                var equipmentDtoList = equipmentList.Select(equipment => new GymEquipmentDto
+                var equipmentDtoList = new List<GymEquipmentDto>();
+
+                foreach (var equipment in equipmentList)
                 {
-                    Id = equipment.Id,
-                    CategoryId = equipment.CategoryId,
-                    Name = equipment.Name,
-                    Brand = equipment.Brand,
-                    Model = equipment.Model,
-                    Quantity = equipment.Quantity,
-                    Image = equipment.Image,
-                    Operational = equipment.Operational == false ? false : null
-                }).ToList();
+                    var quantityInUse = await GetEquipmentUsageCount(equipment.Id); // Await the Task<int> here
+
+                    equipmentDtoList.Add(new GymEquipmentDto
+                    {
+                        Id = equipment.Id,
+                        CategoryId = equipment.CategoryId,
+                        Name = equipment.Name,
+                        Brand = equipment.Brand,
+                        Model = equipment.Model,
+                        Quantity = equipment.Quantity,
+                        Image = equipment.Image,
+                        Operational = equipment.Operational == false ? false : null,
+                        QuantityInUse = quantityInUse // Assign the awaited result
+                    });
+                }
 
                 return equipmentDtoList;
             }


### PR DESCRIPTION
This commit removes the `GetUsageCountForEquipment` method from both `ExerciseController.cs` and `ExerciseService.cs`, eliminating unnecessary error handling. In `GymEquipmentService.cs`, the processing of gym equipment data is updated to initialize an empty list of `GymEquipmentDto` and await the result of `GetEquipmentUsageCount(equipment.Id)` for each equipment record. This ensures that the `QuantityInUse` property is accurately populated in the DTOs, streamlining the handling of equipment usage counts.