### PR TITLE
Change BirthDate type from DateOnly to string

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Dto/UserCompletoDto.cs
+++ b/ApiAcademiaUnifor.ApiService/Dto/UserCompletoDto.cs
@@ -10,7 +10,7 @@ namespace ApiAcademiaUnifor.ApiService.Dto
         public string Password { get; set; } = string.Empty;
         public string? Phone { get; set; } = string.Empty;
         public string? Address { get; set; } = string.Empty;
-        public DateOnly? BirthDate { get; set; }
+        public string? BirthDate { get; set; }
         public string? AvatarUrl { get; set; } = string.Empty;
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/ApiAcademiaUnifor.ApiService/Dto/UserDto.cs
+++ b/ApiAcademiaUnifor.ApiService/Dto/UserDto.cs
@@ -10,7 +10,7 @@ namespace ApiAcademiaUnifor.ApiService.Dto
         public string Password { get; set; } = string.Empty;
         public string? Phone { get; set; }
         public string? Address { get; set; }
-        public DateOnly? BirthDate { get; set; }
+        public string? BirthDate { get; set; }
         public string? AvatarUrl { get; set; }
 
         [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]

--- a/ApiAcademiaUnifor.ApiService/Models/User.cs
+++ b/ApiAcademiaUnifor.ApiService/Models/User.cs
@@ -26,7 +26,7 @@ namespace ApiAcademiaUnifor.ApiService.Models
         public string? Address { get; set; }
 
         [Column("birthDate")]
-        public DateOnly? BirthDate { get; set; }
+        public String? BirthDate { get; set; }
 
         [Column("avatarUrl")]
         public string? AvatarUrl { get; set; }


### PR DESCRIPTION
Updated the `BirthDate` property in `UserCompletoDto`, `UserDto`, and `User` classes to use `string?` instead of `DateOnly?`. This change enhances flexibility in representing birth dates, allowing for various date formats.