### PR TITLE
Refactor nextId calculation in UserService.cs

### DIFF
--- a/ApiAcademiaUnifor.ApiService/Service/UserService.cs
+++ b/ApiAcademiaUnifor.ApiService/Service/UserService.cs
@@ -173,7 +173,7 @@ namespace ApiAcademiaUnifor.ApiService.Service
                 var lista = await _supabase.From<Models.User>().Get();
                 int nextId = lista.Models.Any()
                     ? lista.Models.Max(e => e.Id) + 1
-                    : 1; ;
+                    : 1;
 
                 var user = new Models.User
                 {


### PR DESCRIPTION
Updated the logic for calculating the nextId variable by removing an unnecessary semicolon. The functionality remains unchanged, ensuring that nextId defaults to 1 when there are no entries in lista.Models. This change improves code clarity.